### PR TITLE
Pull the remote item loader from the app container directly

### DIFF
--- a/src/GenerateDefaultCategories.php
+++ b/src/GenerateDefaultCategories.php
@@ -3,6 +3,7 @@
 namespace Camuthig\Jigsaw\DefaultCategories;
 
 use TightenCo\Jigsaw\Jigsaw;
+use TightenCo\Jigsaw\Loaders\CollectionRemoteItemLoader;
 use TightenCo\Jigsaw\Loaders\DataLoader;
 
 class GenerateDefaultCategories
@@ -72,7 +73,9 @@ class GenerateDefaultCategories
 
         $siteData = $dataLoader->loadSiteData($jigsaw->app->config);
 
-        $jigsaw->remoteItemLoader->write($siteData->collections, $jigsaw->getSourcePath());
+        $remoteItemLoader = $jigsaw->app->get(CollectionRemoteItemLoader::class);
+        $remoteItemLoader->write($siteData->collections, $jigsaw->getSourcePath());
+
         $collectionData = $dataLoader->loadCollectionData($siteData, $jigsaw->getSourcePath());
         $jigsaw->getSiteData()->addCollectionData($collectionData);
     }


### PR DESCRIPTION
The `remoteItemLoader` on the `Jigsaw` instance was marked as protected
at some point along the way. This made it impossible to access it
directly from the listener.

The same loader is defined in the app container and injected into the
Jigsaw instance though, and the `$jigsaw->app` variable is still
publicly accessible. So pulling the item loader from the accessible
container provides the same level of functionality. If the app property
were ever to be made protected or private this may no longer work,
though.